### PR TITLE
fixed 'redefined tests' notification 

### DIFF
--- a/test/test_erb_eval.rb
+++ b/test/test_erb_eval.rb
@@ -1,6 +1,6 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 
-class TestSafemodeEval < Test::Unit::TestCase
+class TestERBEval < Test::Unit::TestCase
   include TestHelper
   
   def setup


### PR DESCRIPTION
.Was showing up under 1.9.3 (when using newer test-unit)
