### PR TITLE
Support safe call

### DIFF
--- a/lib/safemode/parser.rb
+++ b/lib/safemode/parser.rb
@@ -29,7 +29,7 @@ module Safemode
     def jail(str, parentheses = false, safe_call: false)
       str = if str
               dot = safe_call ? "&." : "."
-              parentheses ? "(#{str})&#{dot}" : "#{str}#{dot}"
+              parentheses ? "(#{str})#{dot}" : "#{str}#{dot}"
             end
       "#{str}to_jail"
     end

--- a/lib/safemode/parser.rb
+++ b/lib/safemode/parser.rb
@@ -26,19 +26,22 @@ module Safemode
       end
     end
 
-    def jail(str, parentheses = false)
-      str = parentheses ? "(#{str})." : "#{str}." if str
+    def jail(str, parentheses = false, safe_call: false)
+      str = if str
+              dot = safe_call ? "&." : "."
+              parentheses ? "(#{str})&#{dot}" : "#{str}#{dot}"
+            end
       "#{str}to_jail"
     end
 
     # split up #process_call. see below ...
-    def process_call(exp)
+    def process_call(exp, safe_call = false)
       exp.shift # remove ":call" symbol
-      receiver = jail process_call_receiver(exp)
+      receiver = jail(process_call_receiver(exp), safe_call: safe_call)
       name = exp.shift
       args = process_call_args(exp)
 
-      process_call_code(receiver, name, args)
+      process_call_code(receiver, name, args, safe_call)
     end
 
     def process_fcall(exp)
@@ -159,25 +162,39 @@ module Safemode
         end
         args << processed unless (processed.nil? or processed.empty?)
       end
-      args.empty? ? nil : args.join(", ")
+      args
     end
 
-    def process_call_code(receiver, name, args)
+    def process_call_code(receiver, name, args, safe_call)
       case name
-      when :<=>, :==, "!=".to_sym, :<, :>, :<=, :>=, :-, :+, :*, :/, :%, :<<, :>>, :** then
-        "(#{receiver} #{name} #{args})"
+      when *BINARY then
+        if safe_call
+          "#{receiver}&.#{name}(#{args.join(", ")})"
+        elsif args.length > 1
+          "#{receiver}.#{name}(#{args.join(", ")})"
+        else
+          "(#{receiver} #{name} #{args.join(", ")})"
+        end
       when :[] then
-        "#{receiver}[#{args}]"
+        receiver ||= "self"
+        "#{receiver}[#{args.join(", ")}]"
+      when :[]= then
+        receiver ||= "self"
+        rhs = args.pop
+        "#{receiver}[#{args.join(", ")}] = #{rhs}"
+      when :"!" then
+        "(not #{receiver})"
       when :"-@" then
         "-#{receiver}"
       when :"+@" then
         "+#{receiver}"
       else
-        unless receiver.nil? then
-          "#{receiver}.#{name}#{args ? "(#{args})" : args}"
-        else
-          "#{name}#{args ? "(#{args})" : args}"
-        end
+        args     = nil                    if args.empty?
+        args     = "(#{args.join(", ")})" if args
+        receiver = "#{receiver}."         if receiver and not safe_call
+        receiver = "#{receiver}&."        if receiver and safe_call
+
+        "#{receiver}#{name}#{args}"
       end
     end
 

--- a/test/test_safemode_eval.rb
+++ b/test/test_safemode_eval.rb
@@ -17,6 +17,10 @@ class TestSafemodeEval < Test::Unit::TestCase
     end
   end
 
+   def test_safe_navigation_operator
+     assert_equal "1", @box.eval('x = 1; x&.to_s')
+   end
+
   def test_unary_operators_on_instances_of_boolean_vars
     assert @box.eval('not false')
     assert @box.eval('!false')

--- a/test/test_safemode_parser.rb
+++ b/test/test_safemode_parser.rb
@@ -25,6 +25,16 @@ class TestSafemodeParser < Test::Unit::TestCase
     assert_jailed "if true then\n 1\n else\n2\nend", "true ? 1 : 2"
   end
 
+  def test_safe_call_simple
+    assert_jailed '@article&.to_jail&.method', '@article&.method'
+  end
+
+  def test_safe_call_with_complex_args
+    unsafe = "@article&.method_with_kwargs('positional')"
+    jailed = "@article&.to_jail&.method_with_kwargs(\"positional\")"
+    assert_jailed jailed, unsafe
+  end
+
   def test_output_buffer_should_be_assignable
     assert_nothing_raised do
       jail('@output_buffer = ""')


### PR DESCRIPTION
This copies the process_call_code method from ruby2ruby. That also implements process_safe_call which calls process_call with a parameter.

Fixes #40