### PR TITLE
Remove bind method from Safemode::Scope

### DIFF
--- a/lib/safemode.rb
+++ b/lib/safemode.rb
@@ -48,12 +48,12 @@ module Safemode
 
     def eval(code, assigns = {}, locals = {}, &block)
       code = Parser.jail(code)
-      scope = Scope.new(@delegate, @delegate_methods, instance_vars: assigns, locals: locals, &block)
-      result = Kernel.eval(code, scope.get_binding, @filename || __FILE__, @line || __LINE__)
+      @scope = Scope.new(@delegate, @delegate_methods, instance_vars: assigns, locals: locals, &block)
+      Kernel.eval(code, @scope.get_binding, @filename || __FILE__, @line || __LINE__)
     end
-    
+
     def output
       @scope.output
-    end 
+    end
   end
 end

--- a/lib/safemode.rb
+++ b/lib/safemode.rb
@@ -40,15 +40,16 @@ module Safemode
   
   class Box
     def initialize(delegate = nil, delegate_methods = [], filename = nil, line = nil)
-      @scope = Scope.new(delegate, delegate_methods)
+      @delegate = delegate
+      @delegate_methods = delegate_methods
       @filename = filename
       @line = line
     end    
 
     def eval(code, assigns = {}, locals = {}, &block)
       code = Parser.jail(code)
-      binding = @scope.bind(assigns, locals, &block)
-      result = Kernel.eval(code, binding, @filename || __FILE__, @line || __LINE__)
+      scope = Scope.new(@delegate, @delegate_methods, instance_vars: assigns, locals: locals, &block)
+      result = Kernel.eval(code, scope.get_binding, @filename || __FILE__, @line || __LINE__)
     end
     
     def output

--- a/lib/safemode/scope.rb
+++ b/lib/safemode/scope.rb
@@ -1,17 +1,17 @@
 module Safemode
   class Scope < Blankslate
-    def initialize(delegate = nil, delegate_methods = [])
+    def initialize(delegate = nil, delegate_methods = [], instance_vars: {}, locals: {}, &block)
       @delegate = delegate        
       @delegate_methods = delegate_methods
-      @locals = {}
-    end
-    
-    def bind(instance_vars = {}, locals = {}, &block)
       @locals = symbolize_keys(locals) # why can't I just pull them to local scope in the same way like instance_vars?
       instance_vars = symbolize_keys(instance_vars)
       instance_vars.each {|key, obj| eval "@#{key} = instance_vars[:#{key}]" }
       @_safemode_output = ''
-      binding
+      @binding = binding
+    end
+
+    def get_binding
+      @binding
     end
   
     def to_jail

--- a/test/test_safemode_eval.rb
+++ b/test/test_safemode_eval.rb
@@ -80,6 +80,10 @@ class TestSafemodeEval < Test::Unit::TestCase
     assert_raise_security '"#{`ls -a`}"'
   end
 
+  def test_should_not_allow_access_to_bind
+    assert_raise_security "self.bind('an arg')"
+  end
+
   TestHelper.no_method_error_raising_calls.each do |call|
     call.gsub!('"', '\\\\"')
     class_eval %Q(


### PR DESCRIPTION
The bind method could be used to execute arbitrary system commands by leveraging that things passed into it were getting eval'd without any escaping. This should remove the issue completely by making bind unavailable.