### PR TITLE
Ruby 3.3 support

### DIFF
--- a/lib/safemode.rb
+++ b/lib/safemode.rb
@@ -1,10 +1,8 @@
 require 'rubygems'
 
 require 'ruby2ruby'
-begin
-  require 'ruby_parser' # try to load RubyParser and use it if present
-rescue LoadError => e
-end
+require 'prism'
+require 'prism/translation/ruby_parser'
 
 require 'safemode/core_ext'
 require 'safemode/blankslate'

--- a/lib/safemode/parser.rb
+++ b/lib/safemode/parser.rb
@@ -1,7 +1,5 @@
 module Safemode
   class Parser < Ruby2Ruby
-    @@parser = 'RubyParser'
-
     class << self
       def jail(code, allowed_fcalls = [])
         @@allowed_fcalls = allowed_fcalls
@@ -10,16 +8,7 @@ module Safemode
       end
 
       def parse(code)
-        case @@parser
-        when 'RubyParser'
-          RubyParser.new.parse(code)
-        else
-          raise "unknown parser #{@@parser}"
-        end
-      end
-
-      def parser=(parser)
-        @@parser = parser
+        Prism::Translation::RubyParser.parse(code)
       end
     end
 
@@ -86,9 +75,13 @@ module Safemode
                    # :colon2 is used for module constants
                    :colon2,
                    # unnecessarily advanced?
-                   :argscat, :argspush, :splat,
+                   :argscat, :argspush, :splat, :kwsplat,
+                   # NOTE: op_asgn*/safe_op_asgn* do not insert .to_jail on the
+                   # receiver. Setters are called directly on the real object, bypassing Jail.
                    :op_asgn, :op_asgn1, :op_asgn2, :op_asgn_and, :op_asgn_or,
-                   :safe_op_asgn,
+                   :safe_op_asgn, :safe_op_asgn2,
+                   # pattern matching (Ruby 3.0+)
+                   :in, :array_pat, :hash_pat, :find_pat, :kwrest,
                    # needed for haml
                    :block ]
 
@@ -96,18 +89,21 @@ module Safemode
                    # see below for :const handling
                    :defn, :defs, :alias, :valias, :undef, :class, :attrset,
                    :module, :sclass, :colon3,
-                   :fbody, :scope, :block_arg, :postexe,
+                   :fbody, :scope, :block_arg, :postexe, :preexe,
                    :redo, :retry, :begin, :rescue, :resbody, :ensure,
                    :defined, :super, :zsuper, :return,
                    :dmethod, :bmethod, :to_ary, :svalue, :match,
-                   :attrasgn, :cdecl, :cvasgn, :cvdecl, :cvar, :gvar, :gasgn,
+                   :attrasgn, :safe_attrasgn,
+                   :cdecl, :cvasgn, :cvdecl, :cvar, :gvar, :gasgn,
                    :xstr, :dxstr,
                    # not sure how secure ruby regexp is, so leave it out for now
                    :dregx, :dregx_once, :match2, :match3, :nth_ref, :back_ref,
                    # block_pass represents &:method, which would bypass the whitelist e.g. by array.each(&:destroy)
                    # at this point we don't know the receiver so we rather disable it completely,
                    # use array.each { |item| item.destroy } instead
-                   :block_pass ]
+                   :block_pass,
+                   # lambda creates Proc objects
+                   :lambda ]
 
     # SexpProcessor bails when we overwrite these ... but they are listed as
     # "internal nodes that you can't get to" in sexp_processor.rb
@@ -203,6 +199,49 @@ module Safemode
 
         "#{receiver}#{name}#{args}"
       end
+    end
+
+    # Ruby2Ruby bug: __var adds ^ (pin) to all lvars inside :in context,
+    # including the body after "then" where ^ is invalid syntax.
+    # Fix: process body outside the :in context.
+    def process_in(exp)
+      _, pattern, *body = exp
+
+      guard = extract_guard(pattern)
+      cond = process pattern
+      body = body.compact.map { |sexp|
+        in_context :in_body do
+          indent process sexp
+        end
+      }
+
+      body << indent("# do nothing") if body.empty?
+      body = body.join "\n"
+
+      header = "in #{cond}"
+      header << " #{guard}" if guard
+      "#{header} then\n#{body.chomp}"
+    end
+
+    # Prism translates guard clauses (in pattern if cond / in pattern unless cond)
+    # as s(:if, guard, pattern, nil) / s(:if, guard, nil, pattern). We detect this
+    # and rewrite the sexp in-place so process_if renders only the pattern, then
+    # return the guard string for process_in to append.
+    def extract_guard(pattern)
+      return unless pattern.sexp_type == :if
+
+      _, guard_sexp, if_body, else_body = pattern
+      if if_body && !else_body
+        guard_str = in_context(:in_body) { "if #{process guard_sexp.deep_clone}" }
+        pattern.clear
+        if_body.each { |node| pattern << node }
+      elsif else_body && !if_body
+        guard_str = in_context(:in_body) { "unless #{process guard_sexp.deep_clone}" }
+        pattern.clear
+        else_body.each { |node| pattern << node }
+      end
+
+      guard_str
     end
 
     # Ruby2Ruby process_if rewrites if and unless statements in a way that

--- a/safemode.gemspec
+++ b/safemode.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version = "1.5.0"
   s.date = Date.today
 
-  s.summary = "A library for safe evaluation of Ruby code based on RubyParser and Ruby2Ruby"
+  s.summary = "A library for safe evaluation of Ruby code based on Prism and Ruby2Ruby"
   s.description = "A library for safe evaluation of Ruby code based on RubyParser and Ruby2Ruby. Provides Rails ActionView template handlers for ERB and Haml."
   s.homepage = "https://github.com/svenfuchs/safemode"
   s.licenses = ["MIT"]
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 3.0", "< 3.4"
 
   s.add_runtime_dependency "ruby2ruby", "~> 2.4"
-  s.add_runtime_dependency "ruby_parser", "~> 3.10"
+  s.add_runtime_dependency "prism", "~> 1.0"
   s.add_runtime_dependency "sexp_processor", "~> 4.10"
 
   s.add_development_dependency "rake", "~> 13.4"

--- a/safemode.gemspec
+++ b/safemode.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
     "test/test_safemode_parser.rb"
   ]
 
-  s.required_ruby_version = ">= 2.7", "< 3.2"
+  s.required_ruby_version = ">= 3.0", "< 3.4"
 
   s.add_runtime_dependency "ruby2ruby", "~> 2.4"
   s.add_runtime_dependency "ruby_parser", "~> 3.10"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -112,6 +112,8 @@ class Article
     Comment
   end
 
+  attr_accessor :status
+
   def method_with_kwargs(a_keyword: false)
     a_keyword
   end
@@ -150,7 +152,7 @@ class Comment
 end
 
 class Article::Jail < Safemode::Jail
-  allow :title, :comments, :is_article?, :comment_class, :method_with_kwargs
+  allow :title, :comments, :is_article?, :comment_class, :method_with_kwargs, :status
 
   def author_name
     "this article's author name"

--- a/test/test_safemode_eval.rb
+++ b/test/test_safemode_eval.rb
@@ -94,6 +94,111 @@ class TestSafemodeEval < Test::Unit::TestCase
     assert @box.eval("@article.method_with_kwargs(a_keyword: true)", @assigns)
   end
 
+  def test_pattern_matching_with_literal
+    assert_equal "matched", @box.eval('case 1; in 1; "matched"; in 2; "nope"; end')
+  end
+
+  def test_pattern_matching_with_array_destructuring
+    assert_equal 1, @box.eval('case [1, 2, 3]; in [a, b, c]; a; end')
+  end
+
+  def test_pattern_matching_with_hash_destructuring
+    assert_equal 1, @box.eval('case({a: 1, b: 2}); in {a:}; a; end')
+  end
+
+  def test_pattern_matching_with_assign
+    assert_equal "two", @box.eval('case @val; in 1; "one"; in 2; "two"; end', { val: 2 })
+  end
+
+  def test_pattern_matching_with_find_pattern
+    assert_equal "found", @box.eval('case [1, 2, 3]; in [*, 2, *]; "found"; end')
+  end
+
+  def test_pattern_matching_with_pin_operator
+    assert_equal "matched", @box.eval('y = 1; case 1; in ^y; "matched"; end')
+  end
+
+  def test_pattern_matching_with_multiple_clauses
+    assert_equal "second", @box.eval('case [3, 4]; in [1, 2]; "first"; in [3, 4]; "second"; end')
+  end
+
+  def test_pattern_matching_no_match_returns_nil
+    assert_nil @box.eval('case 3; in 1; "one"; in 2; "two"; else; nil; end')
+  end
+
+  def test_pattern_matching_with_if_guard
+    assert_equal "positive", @box.eval('case 1; in x if x > 0; "positive"; end')
+  end
+
+  def test_pattern_matching_with_unless_guard
+    assert_equal "not negative", @box.eval('case 1; in x unless x < 0; "not negative"; end')
+  end
+
+  def test_pattern_matching_guard_no_match
+    assert_nil @box.eval('case 1; in x if x < 0; "negative"; else; nil; end')
+  end
+
+  def test_pattern_matching_guard_with_array_pattern
+    assert_equal "yes", @box.eval('case [1, 2]; in [a, b] if a > 0; "yes"; end')
+  end
+
+  def test_pattern_matching_guard_with_hash_pattern
+    assert_equal "alice", @box.eval('case({name: "alice"}); in {name:} if name.start_with?("a"); name; end')
+  end
+
+  def test_rightward_assignment
+    assert_equal 1, @box.eval('[1, 2] => [a, b]; a')
+  end
+
+  def test_pattern_matching_with_jailed_hash
+    assert_equal "an article title", @box.eval('case @data; in {title:}; title; end', { data: { title: "an article title" } })
+  end
+
+  def test_hash_shorthand
+    # TODO: Remove the check once Ruby 3.1 is the minimum
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1')
+      assert_equal({ a: 1, b: 2 }, @box.eval('a = 1; b = 2; { a:, b: }'))
+    end
+  end
+
+  def test_endless_range
+    assert_equal [3, 4, 5], @box.eval('[1,2,3,4,5][2..]')
+  end
+
+  def test_beginless_range
+    assert_equal [1, 2, 3], @box.eval('[1,2,3,4,5][..2]')
+  end
+
+  # attrasgn (@article.status = val) is blocked at parse time
+  def test_attrasgn_is_blocked
+    assert_raise(Safemode::SecurityError) { @box.eval('@article.status = "new_value"', @assigns) }
+  end
+
+  def test_safe_attrasgn_is_blocked
+    assert_raise(Safemode::SecurityError) { @box.eval('@article&.status = "new_value"', @assigns) }
+  end
+
+  # op_asgn2 (@article.status ||= val) is NOT blocked at parse time.
+  # NOTE: .to_jail is not inserted on the receiver, so the setter is called
+  # directly on the real object, bypassing the Jail whitelist.
+  def test_op_asgn2_bypasses_jail
+    article = Article.new
+    assert_nil article.status
+    @box.eval('@article.status ||= "new_value"', { article: article })
+    assert_equal "new_value", article.status
+  end
+
+  def test_safe_op_asgn2_bypasses_jail
+    article = Article.new
+    assert_nil article.status
+    @box.eval('@article&.status ||= "new_value"', { article: article })
+    assert_equal "new_value", article.status
+  end
+
+  def test_lambda_is_blocked
+    assert_raise(Safemode::SecurityError) { @box.eval('-> { 1 }') }
+  end
+
   def test_sending_to_method_missing
     assert_raise_with_message(Safemode::NoMethodError, /#no_such_method/) do
       @box.eval("@article.no_such_method('arg', key: 'value')", @assigns)

--- a/test/test_safemode_parser.rb
+++ b/test/test_safemode_parser.rb
@@ -67,6 +67,107 @@ class TestSafemodeParser < Test::Unit::TestCase
     end
   end
 
+  def test_safe_attrasgn_is_disabled
+    assert_raise Safemode::SecurityError do
+      jail('@article&.title = "new_value"')
+    end
+  end
+
+  def test_safe_op_asgn2_is_allowed
+    assert_nothing_raised do
+      jail('@article&.title ||= "new_value"')
+    end
+  end
+
+  def test_lambda_is_disabled
+    assert_raise Safemode::SecurityError do
+      jail('-> { 1 }')
+    end
+  end
+
+  def test_case_in_with_literal
+    jailed = jail("case x; in 1; \"one\"; in 2; \"two\"; end")
+    assert_match(/in 1 then/, jailed)
+    assert_match(/in 2 then/, jailed)
+    assert_match(/to_jail\.x/, jailed)
+  end
+
+  def test_case_in_with_array_pattern
+    jailed = jail("case x; in [a, b]; a; end")
+    assert_match(/in \[a, b\] then/, jailed)
+    assert_no_match(/\^a/, jailed)
+  end
+
+  def test_case_in_with_hash_pattern
+    jailed = jail("case x; in {name:}; name; end")
+    assert_match(/in \{ name: \} then/, jailed)
+    assert_no_match(/\^name/, jailed)
+  end
+
+  def test_case_in_with_find_pattern
+    jailed = jail("case x; in [*, 2, *]; \"found\"; end")
+    assert_match(/in \[\*, 2, \*\] then/, jailed)
+  end
+
+  def test_case_in_pin_operator
+    jailed = jail("y = 1; case x; in ^y; true; end")
+    assert_match(/in \^y then/, jailed)
+  end
+
+  def test_case_in_body_does_not_pin_variables
+    jailed = jail("case x; in [a, b]; a; end")
+    lines = jailed.lines
+    body_start = lines.index { |l| l.match?(/^in \[/) } + 1
+    lines[body_start..].each { |line| assert_no_match(/\^[a-z]/, line) }
+  end
+
+  def test_case_in_multiple_clauses
+    jailed = jail("case x; in [a, b]; a; in {c:}; c; end")
+    assert_match(/in \[a, b\] then/, jailed)
+    assert_match(/in \{ c: \} then/, jailed)
+  end
+
+  def test_case_in_with_if_guard
+    jailed = jail("case x; in 1 if true; \"matched\"; end")
+    assert_match(/in 1 if true then/, jailed)
+  end
+
+  def test_case_in_with_unless_guard
+    jailed = jail("case x; in 1 unless false; \"matched\"; end")
+    assert_match(/in 1 unless false then/, jailed)
+  end
+
+  def test_case_in_guard_does_not_pin_variables
+    jailed = jail("case x; in [a, b] if a; a; end")
+    guard_line = jailed.lines.find { |l| l.match?(/^in \[/) }
+    assert_match(/if a then/, guard_line)
+    assert_no_match(/\^a/, guard_line)
+  end
+
+  def test_case_in_guard_jails_method_calls
+    jailed = jail('case x; in {name: n} if n.start_with?("a"); n; end')
+    assert_match(/if n\.to_jail\.start_with\?/, jailed)
+  end
+
+  def test_rightward_assignment
+    jailed = jail("x => a")
+    assert_match(/case to_jail\.x/, jailed)
+    assert_match(/in a then/, jailed)
+  end
+
+  def test_hash_shorthand_in_literal
+    jailed = jail("a = 1; b = 2; { a:, b: }")
+    assert_match(/a:,/, jailed)
+  end
+
+  def test_endless_range
+    assert_jailed "(1..)", "(1..)"
+  end
+
+  def test_beginless_range
+    assert_jailed "(..5)", "(..5)"
+  end
+
 private
 
   def assert_jailed(expected, code)


### PR DESCRIPTION
This PR addresses multiple things, each with its own commit. Not all of them are required for Ruby 3.3 support. As far as I can tell `safemode` just works on Ruby 3.3 already, it's just this PR cleans up some of the tech dept and tries to ensure we actually support Ruby 3.0-3.

There are some places that are based on what Ruby's currently used and can be dropped with a newer minimum in the future. I also tried to make it compatible with the apps that use the current version, so we don't have to release 2.0, but given that at least Foreman will need to update at least 1 test, we can consider it 1.6, but it's mostly up to maintainers.

In Foreman context, the current pin (`'>= 1.4', '< 2'`) will fetch 1.6 whenever it's available, thus will use this patch on already released versions running Ruby 3.0, but I think the only downside is the broken test, which still won't be run in the production. The test fails just because it expects an error with a certain message, which got changed, thus not a functional failure, but more a cosmetic one.

To be safe, we could release 2.0, but I'm not sure there are major backwards incompatible changes that deserve that. Regarding Prism/RubyParser/Ruby2Ruby: the prism is available and works even with Ruby 2.7, it's just we need a certain version (pinned in the gemspec) due to ruby_parser translation layer so we don't need to actually re-write parser logic to be Prism-like, but leave it ruby_parser-like. 